### PR TITLE
x, y pos for Screen example

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ import (
 func main() {
   x, y := robotgo.GetMousePos()
   fmt.Println("pos:", x, y)
-  color := robotgo.GetPixelColor(100, 200)
+  color := robotgo.GetPixelColor(x, y)
   fmt.Println("color----", color)
 } 
 ```


### PR DESCRIPTION
Replaced hardcoded position with the variables `x, y` for [Screen](https://github.com/go-vgo/robotgo#screen) example.