### PR TITLE
respect DISPLAY on linux

### DIFF
--- a/base/xdisplay_c.h
+++ b/base/xdisplay_c.h
@@ -4,7 +4,7 @@
 
 static Display *mainDisplay = NULL;
 static int registered = 0;
-static char *displayName = ":0.0";
+static char *displayName = NULL;
 static int hasDisplayNameChanged = 0;
 
 Display *XGetMainDisplay(void)
@@ -22,6 +22,11 @@ Display *XGetMainDisplay(void)
 		/* Then try using environment variable DISPLAY */
 		if (mainDisplay == NULL) {
 			mainDisplay = XOpenDisplay(NULL);
+		}
+
+		/* Fall back to the most likely :0.0*/
+		if (mainDisplay == NULL) {
+			mainDisplay = XOpenDisplay(":0.0");
 		}
 
 		if (mainDisplay == NULL) {


### PR DESCRIPTION
current code sets a default DISPLAY,  so the block trying the users env is never called.
I removed the default and added it back as fallback, because that appears to be its original intent.