### PR TITLE
[README] Change homebrew/dupes/zlib to zlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ zlib & libpng (bitmap)
     Xcode Command Line Tools
 ```
 brew install libpng
-brew install homebrew/dupes/zlib
+brew install zlib
 ```    
 #### For Windows:
 ```


### PR DESCRIPTION
Change `homebrew/dupes/zlib` to `zlib` in the MAC OS installation instruction. using `homebrew/dupes/zlib` shows warning of deprecation.

Logs - 

```

Tapped 0 formulae (30 files, 23.6KB)
Warning: Use zlib instead of deprecated homebrew/dupes/zlib
==> Downloading https://homebrew.bintray.com/bottles/zlib-1.2.11.sierra.bottle.t
######################################################################## 100.0%
==> Pouring zlib-1.2.11.sierra.bottle.tar.gz

```
Homebrew info

```
Homebrew 1.3.7
Homebrew/homebrew-core (git revision 0725; last commit 2017-11-16)
```
