### PR TITLE
use CBitmap covert to C.MMBitmapRef Fixed #90

### DIFF
--- a/robotgo.go
+++ b/robotgo.go
@@ -835,6 +835,11 @@ func ToBitmap(bit C.MMBitmapRef) Bitmap {
 	return bitmap
 }
 
+// ToBitmap trans C.MMBitmapRef to Bitmap
+func ToMMBitmapRef(bit CBitmap) C.MMBitmapRef {
+	return C.MMBitmapRef(bit)
+}
+
 // GetPortion get portion
 func GetPortion(bit C.MMBitmapRef, x, y, w, h C.size_t) C.MMBitmapRef {
 	var rect C.MMRect


### PR DESCRIPTION

- Issues: #90

**Provide test code:**

```Go
package main

import (
    "fmt"

    "github.com/go-vgo/robotgo"
)

var (
    TestBit robotgo.CBitmap 
)

func main() {
    bit := robotgo.OpenBitmap("test.png")
    TestBit = robotgo.CBitmap(bit)
    test()
}

func test() {
    whereBitmap := robotgo.CaptureScreen(0, 0, 1200, 900)
    x, y := robotgo.FindBitmap(robotgo.ToMMBitmapRef(TestBit), whereBitmap, 0.1)
    fmt.Println("...", x, y)
}
```
    
## Description

Bitmap variable type can use conveniently.😁
