### PR TITLE
change TostringBitmap return Fixed #93

### DIFF
--- a/robotgo.go
+++ b/robotgo.go
@@ -848,12 +848,12 @@ func SaveBitmap(args ...interface{}) string {
 // }
 
 // TostringBitmap tostring bitmap to C.char
-func TostringBitmap(bit C.MMBitmapRef) *C.char {
+func TostringBitmap(bit C.MMBitmapRef) string {
 	// str_bit := C.aTostringBitmap(bit)
 	strBit := C.tostring_Bitmap(bit)
 	// fmt.Println("...", str_bit)
 	// return str_bit
-	return strBit
+	return C.GoString(strBit)
 }
 
 // ToBitmap trans C.MMBitmapRef to Bitmap


### PR DESCRIPTION

- Issues: #93

**Provide test code:**

```Go
bit := robotgo.OpenBitmap("test.png", )
str := robotgo.TostringBitmap(bit)
fmt.Println("...", "test.png str is : " + str, reflect.TypeOf(str))
```
    
## Description
Just see https://github.com/go-vgo/robotgo/issues/93#issuecomment-354088184

