### PR TITLE
fix mac input method keytap not work

### DIFF
--- a/key/keycode_c.h
+++ b/key/keycode_c.h
@@ -132,9 +132,8 @@ MMKeyCode keyCodeForChar(const char c)
 
 #if defined(IS_MACOSX)
 
-CFStringRef createStringForKey(CGKeyCode keyCode)
-{
-	TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardInputSource();
+CFStringRef createStringForKey(CGKeyCode keyCode){
+	TISInputSourceRef currentKeyboard = TISCopyCurrentASCIICapableKeyboardInputSource();
 	CFDataRef layoutData =
 		(CFDataRef)TISGetInputSourceProperty(currentKeyboard,
 		                          kTISPropertyUnicodeKeyLayoutData);


### PR DESCRIPTION
- fix mac input method keytap not work