### PR TITLE
Update FindIds doc and only set name once in loop

### DIFF
--- a/robotgo.go
+++ b/robotgo.go
@@ -1565,7 +1565,8 @@ func FindNames() ([]string, error) {
 	return strArr, err
 }
 
-// FindIds finds the all processes named with a subset of "name" (case insensitive), return matching IDs.
+// FindIds finds the all processes named with a subset of "name" (case insensitive), 
+// return matched IDs.
 func FindIds(name string) ([]int32, error) {
 	var pids []int32
 	nps, err := Process()

--- a/robotgo.go
+++ b/robotgo.go
@@ -1565,7 +1565,7 @@ func FindNames() ([]string, error) {
 	return strArr, err
 }
 
-// FindIds finds the all processes named with a subset of "name" (case insensitive), returning matching IDs.
+// FindIds finds the all processes named with a subset of "name" (case insensitive), return matching IDs.
 func FindIds(name string) ([]int32, error) {
 	var pids []int32
 	nps, err := Process()

--- a/robotgo.go
+++ b/robotgo.go
@@ -1565,7 +1565,7 @@ func FindNames() ([]string, error) {
 	return strArr, err
 }
 
-// FindIds find the all process id by the process name
+// FindIds finds the all processes named with a subset of "name" (case insensitive), returning matching IDs.
 func FindIds(name string) ([]int32, error) {
 	var pids []int32
 	nps, err := Process()
@@ -1573,9 +1573,9 @@ func FindIds(name string) ([]int32, error) {
 		return pids, err
 	}
 
+	name = strings.ToLower(name)
 	for i := 0; i < len(nps); i++ {
 		psname := strings.ToLower(nps[i].Name)
-		name = strings.ToLower(name)
 		abool := strings.Contains(psname, name)
 		if abool {
 			pids = append(pids, nps[i].Pid)


### PR DESCRIPTION
This is an extremely minor change that moves lowecaseing the `name` parameter in `FindIds(name string)` to before the loop, instead of within it. This also updates the documentation around the function to make it easier to understand.