### PR TITLE
type conversion needed in addMouse

### DIFF
--- a/robotgo.go
+++ b/robotgo.go
@@ -1302,7 +1302,7 @@ func AddMouse(btn string, x ...int16) bool {
 			ct = true
 		}
 
-		if ct && e.Kind == hook.MouseDown && e.Button == ukey {
+		if ct && e.Kind == hook.MouseDown && int(e.Button) == ukey {
 			hook.End()
 			break
 		}


### PR DESCRIPTION
For issue: https://github.com/go-vgo/robotgo/issues/199

It seems the `e.Button == ukey` condition will never be true, since they both are different types (uint16 vs int). 

Need to do a type conversion to check that condition correctly.