### PR TITLE
Update go.mod fixing issue "invalid pseudo-version: does not match ve…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,5 +20,6 @@ require (
 
 //golang.org/x/image => github.com/golang/image v0.0.0-20181116024801-cd38e8056d9b
 //replace golang.org/x/sys => github.com/golang/sys v0.0.0-20190109145017-48ac38b7c8cb
+replace github.com/BurntSushi/xgb v0.0.0-20160522221800-27f122750802 => github.com/BurntSushi/xgb 27f122750802
 
 go 1.13


### PR DESCRIPTION
…rsion-control timestamp"

Issue when built with Go v1.13:
github.com/BurntSushi/xgb@v0.0.0-20160522221800-27f122750802: invalid pseudo-version: does not match version-control timestamp (2016-05-22T18:18:43Z)

The pull request will be closed without any reasons if it does not satisfy any of following requirements:

1. Make sure you are targeting the `master` branch, pull requests on release branches are only allowed for bug fixes.
2. Please read contributing guidelines: [CONTRIBUTING](https://github.com/go-vgo/robotgo/blob/master/CONTRIBUTING.md)
3. Describe what your pull request does and which issue you're targeting (if any and **Please use English**)
4. ... if it is not related to any particular issues, explain why we should not reject your pull request.
5. The Commits must use English, must be test and No useless submissions.

**You MUST delete the content above including this line before posting, otherwise your pull request will be invalid.**

**Please provide Issues links to:**

- Issues: #1

**Provide test code:**

```Go
    
```
    
## Description

...
