### PR TITLE
Added support for swedish keys

### DIFF
--- a/key/goKey.h
+++ b/key/goKey.h
@@ -135,6 +135,11 @@ struct KeyNames{
 	{ "lights_kbd_up",    K_LIGHTS_KBD_UP },
 	{ "lights_kbd_down",  K_LIGHTS_KBD_DOWN },
 
+	//Swedish keys
+	{ "å",	K_ARING},
+	{ "ä",	K_ADIAERESIS},
+	{ "ö",	K_ODIAERESIS},
+
 	{ NULL,               K_NOT_A_KEY } /* end marker */
 };
 

--- a/key/keycode.h
+++ b/key/keycode.h
@@ -57,6 +57,7 @@ enum _MMKeyCode {
 	K_F23 = K_NOT_A_KEY,
 	K_F24 = K_NOT_A_KEY,
 
+
 	K_META = kVK_Command,
 	K_LMETA = kVK_Command,
 	K_RMETA = kVK_RightCommand,
@@ -132,6 +133,7 @@ enum _MMKeyCode {
 	K_TAB = XK_Tab,
 	K_ESCAPE = XK_Escape,
 	K_UP = XK_Up,
+
 	K_DOWN = XK_Down,
 	K_RIGHT = XK_Right,
 	K_LEFT = XK_Left,
@@ -222,7 +224,12 @@ enum _MMKeyCode {
 	K_LIGHTS_MON_DOWN = XF86XK_MonBrightnessDown,
 	K_LIGHTS_KBD_TOGGLE = XF86XK_KbdLightOnOff,
 	K_LIGHTS_KBD_UP = XF86XK_KbdBrightnessUp,
-	K_LIGHTS_KBD_DOWN = XF86XK_KbdBrightnessDown
+	K_LIGHTS_KBD_DOWN = XF86XK_KbdBrightnessDown,
+
+	//Swedish keys
+	K_ARING = XK_aring,
+	K_ADIAERESIS = XK_adiaeresis,
+	K_ODIAERESIS = XK_odiaeresis
 };
 
 typedef KeySym MMKeyCode;


### PR DESCRIPTION
- Issues: #326 

**Provide test code:**

```Go
    robotgo.KeyTap("å")
    robotgo.KeyTap("ä")
    robotgo.KeyTap("ö")
```
    
## Description
Added mapping for swedish keys for linux users (X11)
...
