### PR TITLE
Update README.md Section  ####Other to windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ sudo apt install xcb libxcb-xkb-dev x11-xkb-utils libx11-xcb-dev libxkbcommon-x1
 sudo apt install libxkbcommon-dev
 
 sudo apt install xsel xclip
-
-sudo apt-get install gcc-multilib
-sudo apt-get install gcc-mingw-w64
-sudo apt install libz-mingw-w64-dev
 ```
 
 #### Fedora:
@@ -334,6 +330,14 @@ go build main.go
 ```
 
 #### Other to windows
+Install Requirements:
+```bash
+sudo apt-get install gcc-multilib
+sudo apt-get install gcc-mingw-w64
+# fix err: zlib.h: No such file or directory
+sudo apt-get install libz-mingw-w64-dev
+```
+Build the binary:
 ```Go
 GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ go build -x ./
 ```

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ sudo apt install xcb libxcb-xkb-dev x11-xkb-utils libx11-xcb-dev libxkbcommon-x1
 sudo apt install libxkbcommon-dev
 
 sudo apt install xsel xclip
+
+sudo apt-get install gcc-multilib
+sudo apt-get install gcc-mingw-w64
+sudo apt install libz-mingw-w64-dev
 ```
 
 #### Fedora:


### PR DESCRIPTION
**Please provide Issues links to:**

- Issues: #228 #100

**Add code:**

```bash
sudo apt-get install gcc-multilib
sudo apt-get install gcc-mingw-w64
sudo apt-get install libz-mingw-w64-dev
```
    
## Description

I'd try and pass test for cross-compile on ubuntu to windows i386 and x86_64, my case: https://github.com/hi20160616/robotclick/blob/main/.github/workflows/goreleaser.yml

I dig and read many issues here,  and collect the right way to cross-compile for windows binary.  
I think it will help someone like me to fix bugs while cross compile.  
like error `zlib.h cannot find out` usually because of we installed it via source, that not useful on **mingw-w64**.  
I also suggest this update to let newbee easy to use this grand code.

