### PR TITLE
This fixes the disappearing backslash issue

### DIFF
--- a/robotgo.go
+++ b/robotgo.go
@@ -738,6 +738,9 @@ func toUC(text string) []string {
 		textUnQ := textQ[1 : len(textQ)-1]
 
 		st := strings.Replace(textUnQ, "\\u", "U", -1)
+		if st == "\\\\" {
+			st = "\\"
+		}
 		uc = append(uc, st)
 	}
 


### PR DESCRIPTION
- Issues: #351

Test code:

```Go
package main

import (
	"fmt"
	"github.com/go-vgo/robotgo"
)

func main() {
	str := "ab\\cd"
	fmt.Printf("robotgo %s\n", robotgo.GetVersion())
	fmt.Printf("type string: %#v\n", str)
	fmt.Printf("keystrokes : %s\n", str)
	robotgo.TypeStr(str, 100)
	fmt.Println()
}
```

## Description

I really don't know if this is the correct solution for it, but it's a minimal change (3 lines) that doesn't break any tests and solves my problem. Essentially, my theory is that because the quoting code of `toUC()` doubles all backslashes, it causes `XStringToKeySym()` to fail which causes all backslashes to get eaten.  This code tests for this and prevents the doubling.

The proof was in the pudding, and my test code correctly outputs "X\X" on Linux.

I release this under the `robotgo` license, which at this point is Apache.