### PR TITLE
Fixes #258: char* arrays in C not being copied correctly

### DIFF
--- a/window/window.h
+++ b/window/window.h
@@ -646,7 +646,15 @@ char* get_title_by_hand(MData m_data){
 	// Check result value
 	if (result != NULL) {
 		// Convert result to a string
-		char *name = (char*)result;
+		char *name = (char*)calloc(strlen(result)+1, sizeof(char*));
+		char *rptr = (char*)result;
+		char *nptr = name;
+		while (*rptr) {
+			*nptr = *rptr;
+			nptr++;
+			rptr++;
+		}
+		*nptr = '\0';
 		XFree(result);
 
 		if (name != NULL) { return name; }
@@ -658,8 +666,17 @@ char* get_title_by_hand(MData m_data){
 	// Check result value
 	if (result != NULL) {
 		// Convert result to a string
-		char *name = (char*)result;
+		char *name = (char*)calloc(strlen(result)+1, sizeof(char*));
+		char *rptr = (char*)result;
+		char *nptr = name;
+		while (*rptr) {
+			*nptr = *rptr;
+			nptr++;
+			rptr++;
+		}
+		*nptr = '\0';
 		XFree(result);
+
 		return name;
 	}
 


### PR DESCRIPTION
- Issues: #258

**Provide test code:**

```Go
package main

import (
	"fmt"
	"github.com/go-vgo/robotgo"
)

func main() {
	fmt.Printf("GetTitle() = %s\n", robotgo.GetTitle())
	activeWindowPID := robotgo.GetPID()
	fmt.Printf("GetTitle(GetPID()) = %s\n", robotgo.GetTitle(activeWindowPID))
}    
```
    
## Description

The C code for getting window titles was just assigning pointers and then freeing the underlying memory, which was causing garbage to be returned. This code allocates space and copies the string.

Ironically, I just noticed that the Windows code does string copying correctly; it just wasn't done right in the X code.