### PR TITLE
Fixed Linux TypeStr() function input double quote

### DIFF
--- a/robotgo.go
+++ b/robotgo.go
@@ -742,6 +742,9 @@ func ToUC(text string) []string {
 		if st == "\\\\" {
 			st = "\\"
 		}
+		if st == `\"` {
+			st = `"`
+		}
 		uc = append(uc, st)
 	}
 


### PR DESCRIPTION
**Please provide Issues links to:**

- Issues: #

**Provide test code:**

```Go
    
```
    
## Description

...
