### PR TITLE
convert img lose 1 pixel bug

### DIFF
--- a/img.go
+++ b/img.go
@@ -122,7 +122,7 @@ func ImgToBitmap(m image.Image) (bit Bitmap) {
 // ToUint8p convert the []uint8 to uint8 pointer
 func ToUint8p(dst []uint8) *uint8 {
 	src := make([]uint8, len(dst)+10)
-	for i := 0; i < len(dst)-4; i += 4 {
+	for i := 0; i <= len(dst)-4; i += 4 {
 		src[i+3] = dst[i+3]
 		src[i] = dst[i+2]
 		src[i+1] = dst[i+1]
@@ -151,7 +151,7 @@ func val(p *uint8, n int) uint8 {
 }
 
 func copyToVUint8A(dst []uint8, src *uint8) {
-	for i := 0; i < len(dst)-4; i += 4 {
+	for i := 0; i <= len(dst)-4; i += 4 {
 		dst[i] = val(src, i+2)
 		dst[i+1] = val(src, i+1)
 		dst[i+2] = val(src, i)


### PR DESCRIPTION
## Description

Convert img lose 1 pixel.

Example:
```go
package main

import (
	"fmt"

	"github.com/go-vgo/robotgo"
)

func main() {

	// test loop
	var dst [20]int
	for i := 0; i < len(dst); i++ {
		dst[i] = i
	}
	// this loop output only 0~15
	for i := 0; i < len(dst)-4; i += 4 {
		fmt.Print(dst[i], dst[i+1], dst[i+2], dst[i+3], " ")
	}
	fmt.Println("")
	// this loop output 0~19
	for i := 0; i <= len(dst)-4; i += 4 {
		fmt.Print(dst[i], dst[i+1], dst[i+2], dst[i+3], " ")
	}

	// test convert img, test2.png will lose the last 1 pixel
	cbitmap := robotgo.CaptureScreen(0, 0, 20, 20)
	defer robotgo.FreeBitmap(cbitmap)
	robotgo.SaveBitmap(cbitmap, "./test1.png")
	img := robotgo.ToRGBAGo(robotgo.ToBitmap(cbitmap))
	robotgo.SavePng(img, "./test2.png")
}

```
