### PR TITLE
Fix: panic occurs when current window is minimized on macOS 

### DIFF
--- a/window/window.h
+++ b/window/window.h
@@ -367,11 +367,11 @@ MData get_active(void) {
 	if (focused == NULL) { return result; } // Verify
 
 	AXUIElementRef element;
+	CGWindowID win = 0;
 	// Retrieve the currently focused window
 	if (AXUIElementCopyAttributeValue(focused, kAXFocusedWindowAttribute, (CFTypeRef*) &element) 
 		== kAXErrorSuccess && element) {
 
-		CGWindowID win = 0;
 		// Use undocumented API to get WID
 		if (_AXUIElementGetWindow(element, &win) == kAXErrorSuccess && win) {
 			// Manually set internals
@@ -380,6 +380,9 @@ MData get_active(void) {
 		} else {
 			CFRelease(element);
 		}
+	} else {
+		result.CgID = win;
+		result.AxID = element;
 	}
 	CFRelease(focused);
 


### PR DESCRIPTION
Panic occurs when current window is minimized on macOS.

this change will resolve #611 #533

```go
SIGSEGV: segmentation violation
PC=0x1a2c29c20 m=20 sigcode=2
signal arrived during cgo execution

goroutine 39 [syscall]:
runtime.cgocall(0x102fc6478, 0x14002a99ed8)
        /usr/local/go/src/runtime/cgocall.go:157 +0x44 fp=0x14002a99ea0 sp=0x14002a99e60 pc=0x102bca604
github.com/go-vgo/robotgo._Cfunc_get_PID()
        _cgo_gotypes.go:540 +0x34 fp=0x14002a99ed0 sp=0x14002a99ea0 pc=0x102fb7fe4
github.com/go-vgo/robotgo.GetPid(...)
        /Users/mokky/Go/source/the_real/robotgo/robotgo.go:1012
main.(*MainApp).checkPID(0x140003ce300)
        /Users/mokky/Go/source/the_real/handler.go:48 +0x80 fp=0x14002a99fb0 sp=0x14002a99ed0 pc=0x102fba530
main.main.func9()
        /Users/mokky/Go/source/the_real/main.go:26 +0x28 fp=0x14002a99fd0 sp=0x14002a99fb0 pc=0x102fbdd98
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14002a99fd0 sp=0x14002a99fd0 pc=0x102c2f0a4
created by main.main in goroutine 1
        /Users/mokky/Go/source/the_real/main.go:26 +0x68

goroutine 1 [select, locked to thread]:
runtime.gopark(0x140029e1d18?, 0x3?, 0x0?, 0x0?, 0x140029e1cb2?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x140029e1b10 sp=0x140029e1af0 pc=0x102bfe238
runtime.selectgo(0x140029e1d18, 0x140029e1cac, 0x14000c07c68?, 0x0, 0x1031a1ae0?, 0x1)
        /usr/local/go/src/runtime/select.go:327 +0x608 fp=0x140029e1c20 sp=0x140029e1b10 pc=0x102c0ea28
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).runGL(0x140003c6310)
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/loop.go:115 +0x128 fp=0x140029e1d50 sp=0x140029e1c20 pc=0x102f91f88
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).Run(0x140003c6310)
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver.go:168 +0x78 fp=0x140029e1d80 sp=0x140029e1d50 pc=0x102f90b98
fyne.io/fyne/v2/internal/driver/glfw.(*window).ShowAndRun(0x14000452000)
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/window.go:231 +0x2c fp=0x140029e1da0 sp=0x140029e1d80 pc=0x102f9509c
main.main()
        /Users/mokky/Go/source/the_real/main.go:324 +0xb70 fp=0x140029e1f30 sp=0x140029e1da0 pc=0x102fbb320
runtime.main()
        /usr/local/go/src/runtime/proc.go:267 +0x2bc fp=0x140029e1fd0 sp=0x140029e1f30 pc=0x102bfde0c
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140029e1fd0 sp=0x140029e1fd0 pc=0x102c2f0a4

goroutine 2 [force gc (idle)]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000054f90 sp=0x14000054f70 pc=0x102bfe238
runtime.goparkunlock(...)
        /usr/local/go/src/runtime/proc.go:404
runtime.forcegchelper()
        /usr/local/go/src/runtime/proc.go:322 +0xb8 fp=0x14000054fd0 sp=0x14000054f90 pc=0x102bfe0c8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14000054fd0 sp=0x14000054fd0 pc=0x102c2f0a4
created by runtime.init.6 in goroutine 1
        /usr/local/go/src/runtime/proc.go:310 +0x24

goroutine 3 [GC sweep wait]:
runtime.gopark(0x1?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000055760 sp=0x14000055740 pc=0x102bfe238
runtime.goparkunlock(...)
        /usr/local/go/src/runtime/proc.go:404
runtime.bgsweep(0x0?)
        /usr/local/go/src/runtime/mgcsweep.go:321 +0x108 fp=0x140000557b0 sp=0x14000055760 pc=0x102beab08
runtime.gcenable.func1()
        /usr/local/go/src/runtime/mgc.go:200 +0x28 fp=0x140000557d0 sp=0x140000557b0 pc=0x102bdf7f8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140000557d0 sp=0x140000557d0 pc=0x102c2f0a4
created by runtime.gcenable in goroutine 1
        /usr/local/go/src/runtime/mgc.go:200 +0x6c

goroutine 4 [GC scavenge wait]:
runtime.gopark(0x1400007e000?, 0x1030a2850?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000055f50 sp=0x14000055f30 pc=0x102bfe238
runtime.goparkunlock(...)
        /usr/local/go/src/runtime/proc.go:404
runtime.(*scavengerState).park(0x10403c900)
        /usr/local/go/src/runtime/mgcscavenge.go:425 +0x5c fp=0x14000055f80 sp=0x14000055f50 pc=0x102be830c
runtime.bgscavenge(0x0?)
        /usr/local/go/src/runtime/mgcscavenge.go:658 +0xac fp=0x14000055fb0 sp=0x14000055f80 pc=0x102be88cc
runtime.gcenable.func2()
        /usr/local/go/src/runtime/mgc.go:201 +0x28 fp=0x14000055fd0 sp=0x14000055fb0 pc=0x102bdf798
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14000055fd0 sp=0x14000055fd0 pc=0x102c2f0a4
created by runtime.gcenable in goroutine 1
        /usr/local/go/src/runtime/mgc.go:201 +0xac

goroutine 18 [finalizer wait]:
runtime.gopark(0x140001861a0?, 0x1a0?, 0x98?, 0x1?, 0x1031c77e0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000054580 sp=0x14000054560 pc=0x102bfe238
runtime.runfinq()
        /usr/local/go/src/runtime/mfinal.go:193 +0x108 fp=0x140000547d0 sp=0x14000054580 pc=0x102bde8e8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140000547d0 sp=0x140000547d0 pc=0x102c2f0a4
created by runtime.createfing in goroutine 1
        /usr/local/go/src/runtime/mfinal.go:163 +0x80

goroutine 19 [syscall]:
syscall.syscall6(0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/sys_darwin.go:45 +0x68 fp=0x140000503d0 sp=0x14000050310 pc=0x102c2b878
golang.org/x/sys/unix.kevent(0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /Users/mokky/Go/pkg/mod/golang.org/x/sys@v0.12.0/unix/zsyscall_darwin_arm64.go:276 +0x54 fp=0x14000050440 sp=0x140000503d0 pc=0x102fa16d4
golang.org/x/sys/unix.Kevent(0x0?, {0x0?, 0x0?, 0x0?}, {0x14000050660?, 0x0?, 0x0?}, 0x0?)
        /Users/mokky/Go/pkg/mod/golang.org/x/sys@v0.12.0/unix/syscall_bsd.go:398 +0x40 fp=0x14000050480 sp=0x14000050440 pc=0x102fa0b00
github.com/fsnotify/fsnotify.(*Watcher).read(0x0?, {0x14000050660?, 0x0?, 0xa})
        /Users/mokky/Go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_kqueue.go:702 +0x48 fp=0x140000504e0 sp=0x14000050480 pc=0x102fa5548
github.com/fsnotify/fsnotify.(*Watcher).readEvents(0x140003c6380)
        /Users/mokky/Go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_kqueue.go:487 +0x94 fp=0x140000507b0 sp=0x140000504e0 pc=0x102fa4354
github.com/fsnotify/fsnotify.NewWatcher.func1()
        /Users/mokky/Go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_kqueue.go:155 +0x28 fp=0x140000507d0 sp=0x140000507b0 pc=0x102fa2d98
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140000507d0 sp=0x140000507d0 pc=0x102c2f0a4
created by github.com/fsnotify/fsnotify.NewWatcher in goroutine 1
        /Users/mokky/Go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_kqueue.go:155 +0x1f8

goroutine 20 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000050ea0 sp=0x14000050e80 pc=0x102bfe238
runtime.chanrecv(0x140001823c0, 0x14000050fb0, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x14000050f20 sp=0x14000050ea0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x14000050f50 sp=0x14000050f20 pc=0x102bcc504
fyne.io/fyne/v2/app.watchFile.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/app/settings_desktop.go:43 +0x60 fp=0x14000050fd0 sp=0x14000050f50 pc=0x102fac250
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14000050fd0 sp=0x14000050fd0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/app.watchFile in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/app/settings_desktop.go:42 +0xf8

goroutine 34 [syscall]:
syscall.syscall6(0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/sys_darwin.go:45 +0x68 fp=0x140000513d0 sp=0x14000051310 pc=0x102c2b878
golang.org/x/sys/unix.kevent(0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /Users/mokky/Go/pkg/mod/golang.org/x/sys@v0.12.0/unix/zsyscall_darwin_arm64.go:276 +0x54 fp=0x14000051440 sp=0x140000513d0 pc=0x102fa16d4
golang.org/x/sys/unix.Kevent(0x0?, {0x0?, 0x0?, 0x0?}, {0x14000051660?, 0x0?, 0x0?}, 0x0?)
        /Users/mokky/Go/pkg/mod/golang.org/x/sys@v0.12.0/unix/syscall_bsd.go:398 +0x40 fp=0x14000051480 sp=0x14000051440 pc=0x102fa0b00
github.com/fsnotify/fsnotify.(*Watcher).read(0x0?, {0x14000051660?, 0x0?, 0xa})
        /Users/mokky/Go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_kqueue.go:702 +0x48 fp=0x140000514e0 sp=0x14000051480 pc=0x102fa5548
github.com/fsnotify/fsnotify.(*Watcher).readEvents(0x1400041c070)
        /Users/mokky/Go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_kqueue.go:487 +0x94 fp=0x140000517b0 sp=0x140000514e0 pc=0x102fa4354
github.com/fsnotify/fsnotify.NewWatcher.func1()
        /Users/mokky/Go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_kqueue.go:155 +0x28 fp=0x140000517d0 sp=0x140000517b0 pc=0x102fa2d98
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140000517d0 sp=0x140000517d0 pc=0x102c2f0a4
created by github.com/fsnotify/fsnotify.NewWatcher in goroutine 1
        /Users/mokky/Go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_kqueue.go:155 +0x1f8

goroutine 35 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x1400042c6a0 sp=0x1400042c680 pc=0x102bfe238
runtime.chanrecv(0x14000426000, 0x1400042c7b0, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x1400042c720 sp=0x1400042c6a0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x1400042c750 sp=0x1400042c720 pc=0x102bcc504
fyne.io/fyne/v2/app.watchFile.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/app/settings_desktop.go:43 +0x60 fp=0x1400042c7d0 sp=0x1400042c750 pc=0x102fac250
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x1400042c7d0 sp=0x1400042c7d0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/app.watchFile in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/app/settings_desktop.go:42 +0xf8

goroutine 36 [select, locked to thread]:
runtime.gopark(0x1400042cf88?, 0x4?, 0x0?, 0x0?, 0x1400042cf30?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000092dd0 sp=0x14000092db0 pc=0x102bfe238
runtime.selectgo(0x14000092f88, 0x1400042cf28, 0x0?, 0x0, 0x0?, 0x1)
        /usr/local/go/src/runtime/select.go:327 +0x608 fp=0x14000092ee0 sp=0x14000092dd0 pc=0x102c0ea28
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).startDrawThread.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/loop.go:224 +0xa8 fp=0x14000092fd0 sp=0x14000092ee0 pc=0x102f92718
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14000092fd0 sp=0x14000092fd0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).startDrawThread in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/loop.go:220 +0xc4

goroutine 37 [select]:
runtime.gopark(0x1400042d758?, 0x2?, 0xe0?, 0x33?, 0x1400042d6f8?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x1400042d590 sp=0x1400042d570 pc=0x102bfe238
runtime.selectgo(0x1400042d758, 0x1400042d6f4, 0x0?, 0x0, 0x0?, 0x1)
        /usr/local/go/src/runtime/select.go:327 +0x608 fp=0x1400042d6a0 sp=0x1400042d590 pc=0x102c0ea28
fyne.io/fyne/v2/internal/async.(*UnboundedFuncChan).processing(0x1400041a300)
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/async/chan_func.go:45 +0xb0 fp=0x1400042d7b0 sp=0x1400042d6a0 pc=0x102e71480
fyne.io/fyne/v2/internal/async.NewUnboundedFuncChan.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/async/chan_func.go:22 +0x28 fp=0x1400042d7d0 sp=0x1400042d7b0 pc=0x102e71398
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x1400042d7d0 sp=0x1400042d7d0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/async.NewUnboundedFuncChan in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/async/chan_func.go:22 +0xe8

goroutine 38 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x1400042ded0 sp=0x1400042deb0 pc=0x102bfe238
runtime.chanrecv(0x1400043a0c0, 0x1400042dfa0, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x1400042df50 sp=0x1400042ded0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x1400042df80 sp=0x1400042df50 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/common.(*Window).RunEventQueue(0x0?)
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/common/window.go:34 +0x48 fp=0x1400042dfb0 sp=0x1400042df80 pc=0x102f509b8
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).createWindow.func1.1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/window.go:959 +0x28 fp=0x1400042dfd0 sp=0x1400042dfb0 pc=0x102f99ff8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x1400042dfd0 sp=0x1400042dfd0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).createWindow.func1 in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/window.go:959 +0x148

goroutine 41 [select]:
runtime.gopark(0x1400042f758?, 0x2?, 0xe0?, 0x33?, 0x1400042f6f8?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x1400042f590 sp=0x1400042f570 pc=0x102bfe238
runtime.selectgo(0x1400042f758, 0x1400042f6f4, 0x0?, 0x0, 0x0?, 0x1)
        /usr/local/go/src/runtime/select.go:327 +0x608 fp=0x1400042f6a0 sp=0x1400042f590 pc=0x102c0ea28
fyne.io/fyne/v2/internal/async.(*UnboundedFuncChan).processing(0x1400041a3c0)
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/async/chan_func.go:45 +0xb0 fp=0x1400042f7b0 sp=0x1400042f6a0 pc=0x102e71480
fyne.io/fyne/v2/internal/async.NewUnboundedFuncChan.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/async/chan_func.go:22 +0x28 fp=0x1400042f7d0 sp=0x1400042f7b0 pc=0x102e71398
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x1400042f7d0 sp=0x1400042f7d0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/async.NewUnboundedFuncChan in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/async/chan_func.go:22 +0xe8

goroutine 42 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x1400042fed0 sp=0x1400042feb0 pc=0x102bfe238
runtime.chanrecv(0x1400043a1e0, 0x1400042ffa0, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x1400042ff50 sp=0x1400042fed0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x1400042ff80 sp=0x1400042ff50 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/common.(*Window).RunEventQueue(0x0?)
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/common/window.go:34 +0x48 fp=0x1400042ffb0 sp=0x1400042ff80 pc=0x102f509b8
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).createWindow.func1.1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/window.go:959 +0x28 fp=0x1400042ffd0 sp=0x1400042ffb0 pc=0x102f99ff8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x1400042ffd0 sp=0x1400042ffd0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).createWindow.func1 in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/window.go:959 +0x148

goroutine 22 [GC worker (idle)]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000051f30 sp=0x14000051f10 pc=0x102bfe238
runtime.gcBgMarkWorker()
        /usr/local/go/src/runtime/mgc.go:1293 +0xd8 fp=0x14000051fd0 sp=0x14000051f30 pc=0x102be11b8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14000051fd0 sp=0x14000051fd0 pc=0x102c2f0a4
created by runtime.gcBgMarkStartWorkers in goroutine 1
        /usr/local/go/src/runtime/mgc.go:1217 +0x28

goroutine 43 [GC worker (idle)]:
runtime.gopark(0x98eb4229d279?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000428730 sp=0x14000428710 pc=0x102bfe238
runtime.gcBgMarkWorker()
        /usr/local/go/src/runtime/mgc.go:1293 +0xd8 fp=0x140004287d0 sp=0x14000428730 pc=0x102be11b8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140004287d0 sp=0x140004287d0 pc=0x102c2f0a4
created by runtime.gcBgMarkStartWorkers in goroutine 1
        /usr/local/go/src/runtime/mgc.go:1217 +0x28

goroutine 23 [GC worker (idle)]:
runtime.gopark(0x98eb422a6ad1?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000052730 sp=0x14000052710 pc=0x102bfe238
runtime.gcBgMarkWorker()
        /usr/local/go/src/runtime/mgc.go:1293 +0xd8 fp=0x140000527d0 sp=0x14000052730 pc=0x102be11b8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140000527d0 sp=0x140000527d0 pc=0x102c2f0a4
created by runtime.gcBgMarkStartWorkers in goroutine 1
        /usr/local/go/src/runtime/mgc.go:1217 +0x28

goroutine 44 [GC worker (idle)]:
runtime.gopark(0x98eb422ac2de?, 0x1?, 0x13?, 0xbe?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000428f30 sp=0x14000428f10 pc=0x102bfe238
runtime.gcBgMarkWorker()
        /usr/local/go/src/runtime/mgc.go:1293 +0xd8 fp=0x14000428fd0 sp=0x14000428f30 pc=0x102be11b8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14000428fd0 sp=0x14000428fd0 pc=0x102c2f0a4
created by runtime.gcBgMarkStartWorkers in goroutine 1
        /usr/local/go/src/runtime/mgc.go:1217 +0x28

goroutine 24 [GC worker (idle)]:
runtime.gopark(0x98eb422a6d18?, 0x1?, 0x19?, 0x5d?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000052f30 sp=0x14000052f10 pc=0x102bfe238
runtime.gcBgMarkWorker()
        /usr/local/go/src/runtime/mgc.go:1293 +0xd8 fp=0x14000052fd0 sp=0x14000052f30 pc=0x102be11b8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14000052fd0 sp=0x14000052fd0 pc=0x102c2f0a4
created by runtime.gcBgMarkStartWorkers in goroutine 1
        /usr/local/go/src/runtime/mgc.go:1217 +0x28

goroutine 5 [GC worker (idle)]:
runtime.gopark(0x1040733e0?, 0x1?, 0x55?, 0x61?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000056730 sp=0x14000056710 pc=0x102bfe238
runtime.gcBgMarkWorker()
        /usr/local/go/src/runtime/mgc.go:1293 +0xd8 fp=0x140000567d0 sp=0x14000056730 pc=0x102be11b8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140000567d0 sp=0x140000567d0 pc=0x102c2f0a4
created by runtime.gcBgMarkStartWorkers in goroutine 1
        /usr/local/go/src/runtime/mgc.go:1217 +0x28

goroutine 45 [GC worker (idle)]:
runtime.gopark(0x98eb422b0905?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000429730 sp=0x14000429710 pc=0x102bfe238
runtime.gcBgMarkWorker()
        /usr/local/go/src/runtime/mgc.go:1293 +0xd8 fp=0x140004297d0 sp=0x14000429730 pc=0x102be11b8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140004297d0 sp=0x140004297d0 pc=0x102c2f0a4
created by runtime.gcBgMarkStartWorkers in goroutine 1
        /usr/local/go/src/runtime/mgc.go:1217 +0x28

goroutine 25 [GC worker (idle)]:
runtime.gopark(0x98eb422ac526?, 0x3?, 0xcc?, 0xd1?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000053730 sp=0x14000053710 pc=0x102bfe238
runtime.gcBgMarkWorker()
        /usr/local/go/src/runtime/mgc.go:1293 +0xd8 fp=0x140000537d0 sp=0x14000053730 pc=0x102be11b8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140000537d0 sp=0x140000537d0 pc=0x102c2f0a4
created by runtime.gcBgMarkStartWorkers in goroutine 1
        /usr/local/go/src/runtime/mgc.go:1217 +0x28

goroutine 26 [GC worker (idle)]:
runtime.gopark(0x1040733e0?, 0x1?, 0xe?, 0xf0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000053f30 sp=0x14000053f10 pc=0x102bfe238
runtime.gcBgMarkWorker()
        /usr/local/go/src/runtime/mgc.go:1293 +0xd8 fp=0x14000053fd0 sp=0x14000053f30 pc=0x102be11b8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14000053fd0 sp=0x14000053fd0 pc=0x102c2f0a4
created by runtime.gcBgMarkStartWorkers in goroutine 1
        /usr/local/go/src/runtime/mgc.go:1217 +0x28

goroutine 6 [GC worker (idle)]:
runtime.gopark(0x98eb422a7eff?, 0x3?, 0x1b?, 0x16?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000056f30 sp=0x14000056f10 pc=0x102bfe238
runtime.gcBgMarkWorker()
        /usr/local/go/src/runtime/mgc.go:1293 +0xd8 fp=0x14000056fd0 sp=0x14000056f30 pc=0x102be11b8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14000056fd0 sp=0x14000056fd0 pc=0x102c2f0a4
created by runtime.gcBgMarkStartWorkers in goroutine 1
        /usr/local/go/src/runtime/mgc.go:1217 +0x28

goroutine 46 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x14000429ee0 sp=0x14000429ec0 pc=0x102bfe238
runtime.chanrecv(0x14000426300, 0x14000429fb7, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x14000429f60 sp=0x14000429ee0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x14000429f90 sp=0x14000429f60 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:139 +0x3c fp=0x14000429fd0 sp=0x14000429f90 pc=0x102f914dc
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14000429fd0 sp=0x14000429fd0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:138 +0xe8

goroutine 47 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x1400042a6e0 sp=0x1400042a6c0 pc=0x102bfe238
runtime.chanrecv(0x14000426360, 0x1400042a7b7, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x1400042a760 sp=0x1400042a6e0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x1400042a790 sp=0x1400042a760 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:139 +0x3c fp=0x1400042a7d0 sp=0x1400042a790 pc=0x102f914dc
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x1400042a7d0 sp=0x1400042a7d0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:138 +0xe8

goroutine 48 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x1400042aee0 sp=0x1400042aec0 pc=0x102bfe238
runtime.chanrecv(0x140004263c0, 0x1400042afb7, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x1400042af60 sp=0x1400042aee0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x1400042af90 sp=0x1400042af60 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:139 +0x3c fp=0x1400042afd0 sp=0x1400042af90 pc=0x102f914dc
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x1400042afd0 sp=0x1400042afd0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:138 +0xe8

goroutine 49 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x1400042b6e0 sp=0x1400042b6c0 pc=0x102bfe238
runtime.chanrecv(0x14000426420, 0x1400042b7b7, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x1400042b760 sp=0x1400042b6e0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x1400042b790 sp=0x1400042b760 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:139 +0x3c fp=0x1400042b7d0 sp=0x1400042b790 pc=0x102f914dc
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x1400042b7d0 sp=0x1400042b7d0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:138 +0xe8

goroutine 8 [chan receive]:
runtime.gopark(0x140016bcec8?, 0x102f8c18c?, 0x2?, 0x0?, 0x10313d2c0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x140016bcea0 sp=0x140016bce80 pc=0x102bfe238
runtime.chanrecv(0x14002a00060, 0x0, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x140016bcf20 sp=0x140016bcea0 pc=0x102bcc934
runtime.chanrecv1(0x14002a00060?, 0x140016bcf88?)
        /usr/local/go/src/runtime/chan.go:442 +0x14 fp=0x140016bcf50 sp=0x140016bcf20 pc=0x102bcc4e4
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).catchTerm(0x0?)
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:172 +0x7c fp=0x140016bcfb0 sp=0x140016bcf50 pc=0x102f9166c
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).Run.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver.go:167 +0x28 fp=0x140016bcfd0 sp=0x140016bcfb0 pc=0x102f90bf8
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140016bcfd0 sp=0x140016bcfd0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).Run in goroutine 1
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver.go:167 +0x70

goroutine 66 [select, locked to thread]:
runtime.gopark(0x140016b7fa0?, 0x2?, 0x0?, 0x0?, 0x140016b7f9c?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x140016b7e40 sp=0x140016b7e20 pc=0x102bfe238
runtime.selectgo(0x140016b7fa0, 0x140016b7f98, 0x0?, 0x0, 0x0?, 0x1)
        /usr/local/go/src/runtime/select.go:327 +0x608 fp=0x140016b7f50 sp=0x140016b7e40 pc=0x102c0ea28
runtime.ensureSigM.func1()
        /usr/local/go/src/runtime/signal_unix.go:1014 +0x168 fp=0x140016b7fd0 sp=0x140016b7f50 pc=0x102c25998
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140016b7fd0 sp=0x140016b7fd0 pc=0x102c2f0a4
created by runtime.ensureSigM in goroutine 8
        /usr/local/go/src/runtime/signal_unix.go:997 +0xd8

goroutine 27 [syscall]:
runtime.sigNoteSleep(0x0)
        /usr/local/go/src/runtime/os_darwin.go:123 +0x20 fp=0x14002b05f90 sp=0x14002b05f50 pc=0x102bf8860
os/signal.signal_recv()
        /usr/local/go/src/runtime/sigqueue.go:149 +0x2c fp=0x14002b05fb0 sp=0x14002b05f90 pc=0x102c2b10c
os/signal.loop()
        /usr/local/go/src/os/signal/signal_unix.go:23 +0x1c fp=0x14002b05fd0 sp=0x14002b05fb0 pc=0x102f8c67c
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x14002b05fd0 sp=0x14002b05fd0 pc=0x102c2f0a4
created by os/signal.Notify.func1.1 in goroutine 8
        /usr/local/go/src/os/signal/signal.go:151 +0x28

goroutine 28 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x140016baee0 sp=0x140016baec0 pc=0x102bfe238
runtime.chanrecv(0x14002a80060, 0x140016bafb7, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x140016baf60 sp=0x140016baee0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x140016baf90 sp=0x140016baf60 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:139 +0x3c fp=0x140016bafd0 sp=0x140016baf90 pc=0x102f914dc
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140016bafd0 sp=0x140016bafd0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu in goroutine 40
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:138 +0xe8

goroutine 29 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x140016bb6e0 sp=0x140016bb6c0 pc=0x102bfe238
runtime.chanrecv(0x14002a800c0, 0x140016bb7b7, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x140016bb760 sp=0x140016bb6e0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x140016bb790 sp=0x140016bb760 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:139 +0x3c fp=0x140016bb7d0 sp=0x140016bb790 pc=0x102f914dc
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140016bb7d0 sp=0x140016bb7d0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu in goroutine 40
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:138 +0xe8

goroutine 30 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x140016bd6e0 sp=0x140016bd6c0 pc=0x102bfe238
runtime.chanrecv(0x14002a80120, 0x140016bd7b7, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x140016bd760 sp=0x140016bd6e0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x140016bd790 sp=0x140016bd760 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:139 +0x3c fp=0x140016bd7d0 sp=0x140016bd790 pc=0x102f914dc
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140016bd7d0 sp=0x140016bd7d0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu in goroutine 40
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:138 +0xe8

goroutine 82 [chan receive]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x140016b66e0 sp=0x140016b66c0 pc=0x102bfe238
runtime.chanrecv(0x14002a80180, 0x140016b67b7, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x140016b6760 sp=0x140016b66e0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x0?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x140016b6790 sp=0x140016b6760 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:139 +0x3c fp=0x140016b67d0 sp=0x140016b6790 pc=0x102f914dc
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x140016b67d0 sp=0x140016b67d0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu in goroutine 40
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:138 +0xe8

goroutine 31 [chan receive]:
runtime.gopark(0x5?, 0x6?, 0xc0?, 0x0?, 0x14000420000?)
        /usr/local/go/src/runtime/proc.go:398 +0xc8 fp=0x1400042eee0 sp=0x1400042eec0 pc=0x102bfe238
runtime.chanrecv(0x14002a801e0, 0x1400042efb7, 0x1)
        /usr/local/go/src/runtime/chan.go:583 +0x414 fp=0x1400042ef60 sp=0x1400042eee0 pc=0x102bcc934
runtime.chanrecv2(0x0?, 0x102c2f0a4?)
        /usr/local/go/src/runtime/chan.go:447 +0x14 fp=0x1400042ef90 sp=0x1400042ef60 pc=0x102bcc504
fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu.func1()
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:139 +0x3c fp=0x1400042efd0 sp=0x1400042ef90 pc=0x102f914dc
runtime.goexit()
        /usr/local/go/src/runtime/asm_arm64.s:1197 +0x4 fp=0x1400042efd0 sp=0x1400042efd0 pc=0x102c2f0a4
created by fyne.io/fyne/v2/internal/driver/glfw.(*gLDriver).refreshSystrayMenu in goroutine 40
        /Users/mokky/Go/pkg/mod/fyne.io/fyne/v2@v2.4.0/internal/driver/glfw/driver_desktop.go:138 +0xe8

r0      0x104078978
r1      0x1f290b0bd
r2      0x17708d590
r3      0x17708d58c
r4      0x17708d570
r5      0x0
r6      0x1048
r7      0x5dc
r8      0x3c
r9      0x341
r10     0x6ae1000104078978
r11     0x7ffffffffffff8
r12     0xb427386f
r13     0x7fd
r14     0x3c
r15     0x38
r16     0x38
r17     0x1fefedd10
r18     0x0
r19     0x0
r20     0x104078978
r21     0x17708d570
r22     0x17708d58c
r23     0x17708d590
r24     0x17708d58b
r25     0x0
r26     0x1031ca5f8
r27     0x810
r28     0x14000682680
r29     0x17708d4e0
lr      0x1a88241b4
sp      0x17708d4b0
pc      0x1a2c29c20
fault   0x48
```