### PR TITLE
fix: x11 capslock reference the wrong constant

### DIFF
--- a/key/keycode.h
+++ b/key/keycode.h
@@ -179,7 +179,7 @@ enum _MMKeyCode {
 	K_SHIFT = XK_Shift_L,
 	K_LSHIFT = XK_Shift_L,
 	K_RSHIFT = XK_Shift_R,
-	K_CAPSLOCK = XK_Shift_Lock,
+	K_CAPSLOCK = XK_Caps_Lock,
 	K_SPACE = XK_space,
 	K_INSERT = XK_Insert,
 	K_PRINTSCREEN = XK_Print,


### PR DESCRIPTION
**Please provide Issues links to:**

- Issues: [#628](https://github.com/go-vgo/robotgo/issues/628)

**Provide test code:**

```Go
robotgo.KeyTap("capslock")    
```
    
## Description

Use the wrong capslock enum value 