### PR TITLE
fix: DragSmooth Repeat Call MoveScale

### DIFF
--- a/robotgo.go
+++ b/robotgo.go
@@ -540,8 +540,6 @@ func Drag(x, y int, args ...string) {
 //
 //	robotgo.DragSmooth(10, 10)
 func DragSmooth(x, y int, args ...interface{}) {
-	x, y = MoveScale(x, y)
-
 	Toggle("left")
 	MilliSleep(50)
 	MoveSmooth(x, y, args...)


### PR DESCRIPTION
`DragSmooth` calls `MoveScale` followed by `MoveSmooth`, and `MoveSmooth` calls `MoveScale` within `MoveSmooth`, resulting in duplicate calls to `MoveScale`.