### PR TITLE
capture error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-vgo/robotgo
+module github.com/aohanhongzhi/robotgo
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aohanhongzhi/robotgo
+module github.com/go-vgo/robotgo
 
 go 1.17
 

--- a/robotgo.go
+++ b/robotgo.go
@@ -46,6 +46,7 @@ package robotgo
 import "C"
 
 import (
+	"errors"
 	"image"
 	"runtime"
 	"time"
@@ -360,11 +361,14 @@ func CaptureGo(args ...int) Bitmap {
 }
 
 // CaptureImg capture the screen and return image.Image
-func CaptureImg(args ...int) image.Image {
+func CaptureImg(args ...int) (image.Image, error) {
 	bit := CaptureScreen(args...)
+	if bit == nil {
+		return nil, errors.New("capture error")
+	}
 	defer FreeBitmap(bit)
 
-	return ToImage(bit)
+	return ToImage(bit), nil
 }
 
 // FreeBitmap free and dealloc the C bitmap


### PR DESCRIPTION
The pull request will be closed without any reasons if it does not satisfy any of following requirements:

1. Make sure you are targeting the `master` branch, pull requests on release branches are only allowed for bug fixes.
2. Add new features, please provide the reasons and test code.
3. Please read contributing guidelines: [CONTRIBUTING](https://github.com/go-vgo/robotgo/blob/master/CONTRIBUTING.md)
4. Describe what your pull request does and which issue you're targeting (if any and **Please use English**)
5. ... if it is not related to any particular issues, explain why we should not reject your pull request.
6. The Commits must **use English**, must be test and No useless submissions.

**You MUST delete the content above including this line before posting, otherwise your pull request will be invalid.**


**Please provide Issues links to:**

- Issues: #1
```go
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x7ff7f9c6c104]

goroutine 53 [running]:
[github.com/go-vgo/robotgo.ToBitmap(...)](http://github.com/go-vgo/robotgo.ToBitmap(...))
        C:/Users/aohanhongzhi/go/pkg/mod/[github.com/go-vgo/robotgo@v0.110.1/robo](http://github.com/go-vgo/robotgo@v0.110.1/robo)
tgo.go:391
[github.com/go-vgo/robotgo.ToRGBA(0x0?)](http://github.com/go-vgo/robotgo.ToRGBA(0x0?))
        C:/Users/aohanhongzhi/go/pkg/mod/[github.com/go-vgo/robotgo@v0.110.1/robo](http://github.com/go-vgo/robotgo@v0.110.1/robo)
tgo.go:423 +0x24
[github.com/go-vgo/robotgo.ToImage(...)](http://github.com/go-vgo/robotgo.ToImage(...))
        C:/Users/aohanhongzhi/go/pkg/mod/[github.com/go-vgo/robotgo@v0.110.1/robo](http://github.com/go-vgo/robotgo@v0.110.1/robo)
tgo.go:418
[github.com/go-vgo/robotgo.CaptureImg](http://github.com/go-vgo/robotgo.CaptureImg)({0x0?, 0x5?, 0x0?})
        C:/Users/aohanhongzhi/go/pkg/mod/[github.com/go-vgo/robotgo@v0.110.1/robo](http://github.com/go-vgo/robotgo@v0.110.1/robo)
tgo.go:367 +0x59
qq-robot/qq.(*SearchProcessor).execute(0xc00008e060, 0xc00011c580, 0x0?)
        C:/Users/aohanhongzhi/projects/qq-robot/qq/search_processor.go:107 +0x8c
b
qq-robot/qq.(*QQUserInterface).execute(0xc00008e0c0, 0x7ff7f9e06540?, 0xc194618e
3811e224?)
        C:/Users/aohanhongzhi/projects/qq-robot/qq/ui_proccessor.go:33 +0x23a
qq-robot/qq.SendQQGroupMessage({0x1, {0xc00009c040, 0x1c}, {0xc0000a0110, 0x1, 0
x1}, 0x210acd48, {0xc00000a1f0, 0x9}, 0x9f10970c, ...})
        C:/Users/aohanhongzhi/projects/qq-robot/qq/processor.go:23 +0x127
qq-robot/mq.ConsumeExchange.func2({0xc000073c00, 0x3e8, 0x3e8}, 0x0?, {0x7ff7f9f
2a228?, 0xc000088e40?})
        C:/Users/aohanhongzhi/projects/qq-robot/mq/jt_rabbitmq_receive.go:53 +0x
218
[gitee.com/aohanhongzhi/go-rabbitmq-pool.consumeTask](http://gitee.com/aohanhongzhi/go-rabbitmq-pool.consumeTask)(0x0, 0xc0000b0000, 0xc000062
f60)
        C:/Users/aohanhongzhi/go/pkg/mod/[gitee.com/aohanhongzhi/go-rabbitmq-pool](http://gitee.com/aohanhongzhi/go-rabbitmq-pool)
@v0.1.3/RabbitmqPool.go:902 +0x139a
[gitee.com/aohanhongzhi/go-rabbitmq-pool.rListenerConsume.func1](http://gitee.com/aohanhongzhi/go-rabbitmq-pool.rListenerConsume.func1)(0x0?, 0x0?, 0x0?)
        C:/Users/aohanhongzhi/go/pkg/mod/[gitee.com/aohanhongzhi/go-rabbitmq-pool](http://gitee.com/aohanhongzhi/go-rabbitmq-pool)
@v0.1.3/RabbitmqPool.go:789 +0x13
created by [gitee.com/aohanhongzhi/go-rabbitmq-pool.rListenerConsume](http://gitee.com/aohanhongzhi/go-rabbitmq-pool.rListenerConsume) in goroutine
 52
        C:/Users/aohanhongzhi/go/pkg/mod/[gitee.com/aohanhongzhi/go-rabbitmq-pool](http://gitee.com/aohanhongzhi/go-rabbitmq-pool)
@v0.1.3/RabbitmqPool.go:788 +0x2f
```

**Provide test code:**

```Go
    
```
    
## Description

...
