### PR TITLE
add CMData type return

### DIFF
--- a/examples/window/main.go
+++ b/examples/window/main.go
@@ -34,6 +34,9 @@ func get() {
 	// get current Window Active
 	mdata := robotgo.GetActive()
 
+	// get current Window Active , return CMData
+	cmdata := robotgo.GetActiveCMData()
+
 	// get current Window Handle
 	hwnd := robotgo.GetHandle()
 	fmt.Println("hwnd---", hwnd)
@@ -44,6 +47,9 @@ func get() {
 
 	// set Window Active
 	robotgo.SetActive(mdata)
+
+	// set Window Active by CMData
+	robotgo.SetActiveByCMData(cmdata)
 }
 
 func findIds() {

--- a/robotgo.go
+++ b/robotgo.go
@@ -33,6 +33,10 @@ package robotgo
 #cgo darwin CFLAGS: -x objective-c -Wno-deprecated-declarations
 #cgo darwin LDFLAGS: -framework Cocoa -framework OpenGL -framework IOKit
 #cgo darwin LDFLAGS: -framework Carbon -framework CoreFoundation
+//
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > MAC_OS_VERSION_14_4
+#cgo darwin LDFLAGS: -framework ScreenCaptureKit
+#endif
 
 #cgo linux CFLAGS: -I/usr/src
 #cgo linux LDFLAGS: -L/usr/src -lm -lX11 -lXtst

--- a/robotgo.go
+++ b/robotgo.go
@@ -90,6 +90,7 @@ type (
 	CHex C.MMRGBHex
 	// CBitmap define CBitmap as C.MMBitmapRef type
 	CBitmap C.MMBitmapRef
+	CMData  C.MData
 )
 
 // Bitmap define the go Bitmap struct
@@ -874,11 +875,23 @@ func SetActive(win C.MData) {
 	C.set_active(win)
 }
 
+// SetActiveByCMData set the window active by CMData
+func SetActiveByCMData(win CMData) {
+	C.set_active((C.MData)(win))
+}
+
 // GetActive get the active window
 func GetActive() C.MData {
 	mdata := C.get_active()
 	// fmt.Println("active----", mdata)
 	return mdata
+}
+
+// GetActiveCMData get the active window, return CMData
+func GetActiveCMData() CMData {
+	mdata := C.get_active()
+	// fmt.Println("active----", mdata)
+	return (CMData)(mdata)
 }
 
 // MinWindow set the window min


### PR DESCRIPTION
**Please provide Issues links to:**

- 

**Provide test code:**

```Go

	// get current Window Active , return CMData
	cmdata := robotgo.GetActiveCMData()

	// set Window Active by CMData
	robotgo.SetActiveByCMData(cmdata)
    
```
    
## Description

In macos, I cannot get the pid of the wechat child window, so I can only use GetActive and SetActive to operate. However, since there is no secondary definition of the C.MData type, it is difficult to do the intermediate comparison operation, so I submitted This PR hopes to add CMData type return, and also add GetActiveCMData and SetActiveByCMData to facilitate operation.

By the way, since I am using it under macos15, I have to make adjustments based on the branch of https://github.com/go-vgo/robotgo/pull/682
