### PR TITLE
Fixed pointer implicit conversion behavior

### DIFF
--- a/screen/screengrab_c.h
+++ b/screen/screengrab_c.h
@@ -90,7 +90,7 @@ MMBitmapRef copyMMBitmapFromDisplayInRect(MMRectInt32 rect, int32_t display_id, 
 	if (!imageData) { return NULL; }
 
 	bufferSize = CFDataGetLength(imageData);
-	buffer = malloc(bufferSize);
+	buffer = (uint8_t *)malloc(bufferSize);
 	CFDataGetBytes(imageData, CFRangeMake(0, bufferSize), buffer);
 
 	bitmap = createMMBitmap_c(buffer, 


### PR DESCRIPTION
**Please provide Issues links to:**

- Issues: #696 

**Provide test code:**

No test code needed.
    
## Description
screengrab_c.h has a pointer implicit conversion behavior at line 93 (from void* to uint8_t *).
I added an explicit conversion to it.