### PR TITLE
Fix: fix SIGSEGV/SIGBUS crash in macOS keyboard functions

### DIFF
--- a/key/keycode_c.h
+++ b/key/keycode_c.h
@@ -38,8 +38,12 @@ MMKeyCode keyCodeForChar(const char c) {
 
 		charStr = CFStringCreateWithCharacters(kCFAllocatorDefault, &character, 1);
 		/* Our values may be NULL (0), so we need to use this function. */
-		if (!CFDictionaryGetValueIfPresent(charToCodeDict, charStr, (const void **)&code)) {
+		/* Use pointer-sized variable to avoid stack overflow on 64-bit systems */
+		const void *codePtr = NULL;
+		if (!CFDictionaryGetValueIfPresent(charToCodeDict, charStr, &codePtr)) {
 			code = UINT16_MAX; /* Error */
+		} else {
+			code = (CGKeyCode)(uintptr_t)codePtr;
 		}
 		CFRelease(charStr);
 
@@ -92,10 +96,17 @@ MMKeyCode keyCodeForChar(const char c) {
 	CFStringRef createStringForKey(CGKeyCode keyCode){
 		// TISInputSourceRef currentKeyboard = TISCopyCurrentASCIICapableKeyboardInputSource();
 		TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardLayoutInputSource();
+
+		/* Check if currentKeyboard is NULL to avoid crash */
+		if (currentKeyboard == NULL) { return NULL; }
+
 		CFDataRef layoutData = (CFDataRef) TISGetInputSourceProperty(
 			currentKeyboard, kTISPropertyUnicodeKeyLayoutData);
 
-		if (layoutData == nil) { return 0; }
+		if (layoutData == nil) {
+			CFRelease(currentKeyboard);  /* Fix memory leak */
+			return NULL;
+		}
 
 		const UCKeyboardLayout *keyboardLayout = (const UCKeyboardLayout *) CFDataGetBytePtr(layoutData);
 		UInt32 keysDown = 0;


### PR DESCRIPTION
## Description

Fix SIGSEGV/SIGBUS crashes in macOS keyboard functions.

**Fixes:** [#690](https://github.com/go-vgo/robotgo/issues/690), [#732](https://github.com/go-vgo/robotgo/issues/732), [#486](https://github.com/go-vgo/robotgo/issues/486)

### Related Issues Analysis

| Issue | Title | Environment | Symptom |
|-------|-------|-------------|---------|
| [#690](https://github.com/go-vgo/robotgo/issues/690) | Keyboard Function Crashes on macOS | macOS 15.0, M3 (arm64), Go 1.22.4 | SIGSEGV/SIGBUS in `_Cfunc_keyCodeForChar()` when calling `KeyTap`/`KeyToggle`/`KeyUp`/`KeyDown` |
| [#732](https://github.com/go-vgo/robotgo/issues/732) | robotgo.KeyTap Fails on Macos X86 | macOS X86, Go 1.24.0 | SIGSEGV at address `0x8` in `_Cfunc_keyCodeForChar(0x76)` when calling `KeyTap("v","cmd")` |
| [#486](https://github.com/go-vgo/robotgo/issues/486) | KeyTap Segmentation Violation | macOS 10.13.4 ~ 14.4+, Intel & Apple Silicon | Long-standing issue (since 2022) with 13+ reports, crash in `keyCodeForChar()` |

**Common pattern:** All three issues crash at the same location (`keyCodeForChar`) with SIGSEGV at address `0x8`, which is the signature of stack corruption from writing 8 bytes into a 2-byte variable.

### Root Cause

In `keyCodeForChar()`, the code passes a `CGKeyCode*` (2 bytes) to `CFDictionaryGetValueIfPresent()` which expects `const void**` (8 bytes on 64-bit). This overwrites adjacent stack memory, causing crashes when critical data is affected.

**Technical details with official documentation:**

- [`CGKeyCode`](https://developer.apple.com/documentation/coregraphics/cgkeycode) is defined as `UInt16` (16-bit / 2 bytes)
- [`CFDictionaryGetValueIfPresent()`](https://developer.apple.com/documentation/corefoundation/cfdictionarygetvalueifpresent(_:_:_:)) third parameter is `const void**`, which writes a **pointer-sized value**
- On 64-bit macOS ([LP64 data model](https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/64bitPorting/transition/transition.html)), pointers are 8 bytes

When `CFDictionaryGetValueIfPresent()` writes 8 bytes into a 2-byte `CGKeyCode` variable, it corrupts 6 bytes of adjacent stack memory.

The crash manifests on different macOS configurations depending on stack layout (compiler version, optimization level, ABI). Affected reports span:
- Apple Silicon M1/M3 (#690)
- Intel x86_64 (#732)
- Multiple macOS versions 10.13 - 15.x (#486)

### Changes

**`key/keycode_c.h`:**

1. `keyCodeForChar()`: Use pointer-sized variable for `CFDictionaryGetValueIfPresent()`
2. `createStringForKey()`: Add NULL check for `TISCopyCurrentKeyboardLayoutInputSource()` and fix memory leak when `layoutData` is nil
   - Note: `TISGetInputSourceProperty` can return NULL with certain input methods (e.g., Japanese keyboards). See [Apple Developer Forums discussion](https://developer.apple.com/forums/thread/124268).

### References

- [CFDictionaryGetValueIfPresent | Apple Developer Documentation](https://developer.apple.com/documentation/corefoundation/cfdictionarygetvalueifpresent(_:_:_:))
- [CGKeyCode | Apple Developer Documentation](https://developer.apple.com/documentation/coregraphics/cgkeycode)
- [Major 64-Bit Changes (LP64) | Apple Developer Documentation](https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/64bitPorting/transition/transition.html)
- [Making Code 64-Bit Clean | Apple Developer Documentation](https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/64bitPorting/MakingCode64-BitClean/MakingCode64-BitClean.html)
- [TISGetInputSourceProperty documentation | Apple Developer Forums](https://developer.apple.com/forums/thread/124268)

### Testing

- [x] Tested on macOS (Apple Silicon)
- [x] Verified with reproduction code from #690

---

Signed-off-by: PekingSpades <180665176+PekingSpades@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling stability on macOS with enhanced pointer management
  * Fixed potential memory leak in keyboard layout data processing
  * Added safety checks to prevent crashes from null keyboard data

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->